### PR TITLE
fix(ci): restore clean deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,6 @@ jobs:
       - name: Build site
         run: pnpm run build
 
-      # Workaround: @astrojs/cloudflare generates assets.binding="ASSETS" in
-      # dist/server/wrangler.json, but "ASSETS" is reserved in Pages projects
-      # since wrangler 4.76.0. Pages injects the ASSETS binding automatically,
-      # so it's safe to remove. Track: https://github.com/withastro/adapters/issues
-      - name: Remove reserved ASSETS binding from generated config
-        run: node -e "const f='dist/server/wrangler.json';const c=JSON.parse(require('fs').readFileSync(f));delete c.assets;require('fs').writeFileSync(f,JSON.stringify(c))"
-
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
PR #21 merge zombie re-introduced the 'Remove reserved ASSETS binding' step, which fails because the site is 100% static (no dist/server/wrangler.json). This restores the correct workflow
  that already lives on develop.